### PR TITLE
prevent duplication of transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,26 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/elliptic": "^6.4.12",
         "@types/node": "^15.6.0",
         "elliptic": "^6.5.4",
         "typescript": "^4.2.4"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "dependencies": {
+        "@types/bn.js": "*"
       }
     },
     "node_modules/@types/node": {
@@ -90,6 +107,22 @@
     }
   },
   "dependencies": {
+    "@types/bn.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "requires": {
+        "@types/bn.js": "*"
+      }
+    },
     "@types/node": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/ethan-xd/bitsus#readme",
   "description": "",
   "dependencies": {
+    "@types/elliptic": "^6.4.12",
     "@types/node": "^15.6.0",
     "elliptic": "^6.5.4",
     "typescript": "^4.2.4"

--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -1,8 +1,9 @@
 import * as crypto from "crypto";
 import { pkToWallet, walletToPk } from './func/convertBase';
+import {ec} from "elliptic";
+import Signature = ec.Signature;
 
-const ECLib = require('elliptic').ec;
-const ec = new ECLib('secp256k1');
+const secp = new ec('secp256k1');
 
 function sha256(m: string) {
     return crypto.createHash("sha256").update(m).digest("hex");
@@ -31,7 +32,7 @@ function newDifficulty(difficulty: number, time: number) {
 }
 
 export class Transaction {
-    public signature?: string;
+    public signature?: Signature;
     public timestamp: number;
 
     constructor(public amount: number, public fromAddress: string, public toAddress: string) {
@@ -43,7 +44,7 @@ export class Transaction {
     }
 
     signTransaction(privateKey: string) {
-        let key = ec.keyFromPrivate(privateKey);
+        let key = secp.keyFromPrivate(privateKey);
 
         let pk = key.getPublic('hex');
 
@@ -59,16 +60,26 @@ export class Transaction {
     verifySignature() {
         if (this.signature === undefined) return false;
 
-        let key = ec.keyFromPublic(walletToPk(this.fromAddress), 'hex');
+        let key = secp.keyFromPublic(walletToPk(this.fromAddress), 'hex');
 
         return key.verify(this.getHash(), this.signature);
+    }
+
+    getSignatureHash() {
+        let str = "";
+
+        if (this.signature === undefined) return str;
+
+        for (let n of this.signature.toDER()) str += n;
+
+        return sha256(sha256(str));
     }
 }
 
 
 class Block {
     constructor(public nonce: number, public timestamp: number, public coinbase: string, public transactions: Transaction[], public previousHash: string) {
-        // sussy chungus
+        // Intentionally left blank
     }
 
     getHash() {
@@ -169,6 +180,8 @@ export class Blockchain {
 
         if (block.previousHash != this.chain[blockIndex - 1].getHash()) return false;
 
+        let signatureHashes: string[] = [];
+
         for (let tx of block.transactions) {
             let fromBalance = this.getWalletBalance(tx.fromAddress);
 
@@ -176,6 +189,12 @@ export class Blockchain {
                 console.log(`${tx.fromAddress} -> ${tx.toAddress} $${tx.amount} is not heckin valid`);
                 return false;
             }
+
+            let txSigHash = tx.getSignatureHash();
+
+            if (signatureHashes.includes(txSigHash)) return false;
+
+            signatureHashes.push(txSigHash);
 
             if (!tx.verifySignature()) return false;
         }

--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import { pkToWallet, walletToPk } from './func/convertBase';
-import {ec} from "elliptic";
+import { ec } from "elliptic";
 import Signature = ec.Signature;
 
 const secp = new ec('secp256k1');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 import { Blockchain, Transaction } from './blockchain';
-const ECLib = require('elliptic').ec;
-const ec = new ECLib('secp256k1');
+import { ec } from "elliptic";
 import { pkToWallet, walletToPk } from './func/convertBase';
+
+const secp = new ec('secp256k1');
 
 let blockchain = new Blockchain(45, 100);
 
 
 
-let key0 = ec.keyFromPrivate('1');
-let key1 = ec.genKeyPair();
-let key2 = ec.genKeyPair();
-let key3 = ec.genKeyPair();
+let key0 = secp.keyFromPrivate('1');
+let key1 = secp.genKeyPair();
+let key2 = secp.genKeyPair();
+let key3 = secp.genKeyPair();
 
 let k0w = pkToWallet(key0.getPublic('hex'));
 let k1w = pkToWallet(key1.getPublic('hex'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ const secp = new ec('secp256k1');
 
 let blockchain = new Blockchain(45, 100);
 
-
+/*
+ * Keypairs
+ */
 
 let key0 = secp.keyFromPrivate('1');
 let key1 = secp.genKeyPair();
@@ -24,12 +26,18 @@ console.log("PRVKEY: 1");
 console.log("PUBKEY:", key0.getPublic('hex'));
 console.log("WALLET:", pkToWallet(key0.getPublic('hex')));
 
+/*
+ * Test transaction
+ */
+
 let myTransaction = new Transaction(20, k0w, k1w);
 myTransaction.signTransaction(key0.getPrivate('hex'));
 
 console.log("myTransaction, signature valid and cute?", myTransaction.verifySignature());
 
-
+/*
+ * Test block
+ */
 
 let block = blockchain.addBlock(k0w, [myTransaction]);
 
@@ -43,10 +51,9 @@ console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
 console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 
-
-/***************************************************************/
-
-
+/*
+ * Duplicate previously done transaction from block 2 into block 2
+ */
 let transactions = [
     new Transaction(20, k0w, k1w),
     new Transaction(40, k1w, k3w)
@@ -55,22 +62,20 @@ let transactions = [
 transactions[0].signTransaction(key0.getPrivate('hex'));
 transactions[1].signTransaction(key1.getPrivate('hex'));
 
-
-let jeffBlock = blockchain.addBlock(k2w, transactions);
+let block2 = blockchain.addBlock(k2w, transactions);
 
 console.log("Mining block 2...");
-jeffBlock.mine(blockchain.difficulty);
+block2.mine(blockchain.difficulty);
 
-console.log("block heckin valid and cute?", blockchain.verifyBlockchain());
+console.log("Block 2 before duplication. Valid?", blockchain.verifyBlockchain());
 
 console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
 console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
 console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 
-// Duplicate previously done transaction from block 2 into block 2
-jeffBlock.transactions.push(jeffBlock.transactions[0]);
-jeffBlock.mine(blockchain.difficulty);
+block2.transactions.push(block2.transactions[0]);
+block2.mine(blockchain.difficulty);
 
 console.log("Remined with duplicated transaction...should not be valid. is it valid?", blockchain.verifyBlockchain());
 
@@ -78,3 +83,4 @@ console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
 console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
 console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,4 +67,13 @@ console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
 console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 
+// Duplicate previously done transaction from block 2 into block 2
+jeffBlock.transactions.push(jeffBlock.transactions[0]);
+jeffBlock.mine(blockchain.difficulty);
 
+console.log("Remined with duplicated transaction...should not be valid. is it valid?", blockchain.verifyBlockchain());
+
+console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
+console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
+console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
+console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ let block = blockchain.addBlock(k0w, [myTransaction]);
 console.log("Mining block 1...");
 block.mine(blockchain.difficulty);
 
-console.log("block heckin valid and cute?", blockchain.verifyBlockchain());
+console.log("block heckin valid and cute?", blockchain.verifyBlock(1));
 
 console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
 console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
@@ -52,7 +52,7 @@ console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 
 /*
- * Duplicate previously done transaction from block 2 into block 2
+ * Duplicate previously done transaction from block 3 into block 3 (Should make block invalid)
  */
 let transactions = [
     new Transaction(20, k0w, k1w),
@@ -64,10 +64,10 @@ transactions[1].signTransaction(key1.getPrivate('hex'));
 
 let block2 = blockchain.addBlock(k2w, transactions);
 
-console.log("Mining block 2...");
+console.log("\n\nMining block 2...");
 block2.mine(blockchain.difficulty);
 
-console.log("Block 2 before duplication. Valid?", blockchain.verifyBlockchain());
+console.log("Block 2 before duplication. Valid?", blockchain.verifyBlock(2));
 
 console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
 console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
@@ -77,10 +77,27 @@ console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 block2.transactions.push(block2.transactions[0]);
 block2.mine(blockchain.difficulty);
 
-console.log("Remined with duplicated transaction...should not be valid. is it valid?", blockchain.verifyBlockchain());
+console.log("Remined with duplicated transaction from same block...should not be valid. is it valid?", blockchain.verifyBlock(2));
 
 console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
 console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
 console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
 console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);
 
+
+/*
+ * Duplicate previously done transaction from block 1 into block 2 (Should make block invalid)
+ */
+transactions = [block2.transactions[0]];
+
+let block3 = blockchain.addBlock(k2w, transactions);
+
+console.log("\n\nMining block 3...");
+block3.mine(blockchain.difficulty);
+
+console.log("Duplicated transaction from block 2...should not be valid. is it valid?", blockchain.verifyBlock(3));
+
+console.log(`${k0w}: ${blockchain.getWalletBalance(k0w)}`);
+console.log(`${k1w}: ${blockchain.getWalletBalance(k1w)}`);
+console.log(`${k2w}: ${blockchain.getWalletBalance(k2w)}`);
+console.log(`${k3w}: ${blockchain.getWalletBalance(k3w)}`);


### PR DESCRIPTION
this branch prevents duplication of transactions via:

* invalidating a block if the same transaction signature is already in a block's transactions, or
* invalidating a block if the same transaction signature is found in a previous block, although is very inefficient and in future needs a better method.

closes #2, closes #4, closes #5

however need new issue for more efficient method.